### PR TITLE
Add perceptual loss network, data batcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tensorboard-log/
 *.pyc
 *.DS_STORE
 venv/
+data/

--- a/Style Transfer.ipynb
+++ b/Style Transfer.ipynb
@@ -17,7 +17,7 @@
     "import os\n",
     "\n",
     "# Local imports\n",
-    "from vgg_network import load_image\n",
+    "from network_helpers import load_image\n",
     "from style_helpers import gramian"
    ]
   },

--- a/coco_data.py
+++ b/coco_data.py
@@ -1,0 +1,22 @@
+import numpy as np
+from os import listdir
+from os.path import isfile, join
+
+from network_helpers import load_image
+
+class COCODataBatcher(object):
+
+    def __init__(self, path):
+        self.path = path
+        all_files = listdir(self.path)
+        self.files = [f for f in all_files if isfile(join(self.path, f))]
+        self.current_index = 0
+        self.num_files = len(self.files)
+
+    def get_batch(self, batch_size):
+        assert batch_size < self.num_files, 'Batch size bigger than file count'
+        if self.current_index + batch_size > self.num_files:
+            self.current_index = 0
+        file_batch = self.files[self.current_index:self.current_index + batch_size]
+        self.current_index += batch_size
+        return np.array([load_image(join(self.path, filename)) for filename in file_batch])

--- a/network_helpers.py
+++ b/network_helpers.py
@@ -18,6 +18,12 @@ def load_image(path):
     resized_img = skimage.transform.resize(crop_img, (224, 224))
     return resized_img
 
+def conv2d_block_with_weights(input_layer, kernel_size, num_filters, stride=1):
+    # TODO: Consolidate this with conv_block from texture_network
+    conv = conv2d_with_weights(input_layer, kernel_size, num_filters, stride=stride)
+    bn = spatial_batch_norm(conv)
+    return tf.nn.relu(bn)
+
 def conv2d_with_weights(input_layer, kernel_size, num_filters, name="conv2d", stride=1):
     in_channels = input_layer.get_shape().as_list()[-1] # This assumes a certain ordering :/
     weights = tf.Variable(tf.random_uniform([kernel_size, kernel_size, in_channels, num_filters]), name=name+'-weights')

--- a/network_helpers.py
+++ b/network_helpers.py
@@ -1,0 +1,46 @@
+import skimage.io
+import skimage.transform
+import tensorflow as tf
+
+def load_image(path):
+    """
+    Taken from https://github.com/ry/tensorflow-vgg16/blob/master/tf_forward.py
+    """
+    # load image
+    img = skimage.io.imread(path) / 255.0
+    assert (0 <= img).all() and (img <= 1.0).all()
+    # we crop image from center
+    short_edge = min(img.shape[:2])
+    yy = int((img.shape[0] - short_edge) / 2)
+    xx = int((img.shape[1] - short_edge) / 2)
+    crop_img = img[yy : yy + short_edge, xx : xx + short_edge]
+    # resize to 224, 224
+    resized_img = skimage.transform.resize(crop_img, (224, 224))
+    return resized_img
+
+def conv2d_with_weights(input_layer, kernel_size, num_filters, name="conv2d", stride=1):
+    in_channels = input_layer.get_shape().as_list()[-1] # This assumes a certain ordering :/
+    weights = tf.Variable(tf.random_uniform([kernel_size, kernel_size, in_channels, num_filters]), name=name+'-weights')
+    biases = tf.Variable(tf.random_uniform([num_filters]), name=name+'-biases')
+    conv_output = tf.nn.conv2d(input_layer, weights, strides=[1, stride, stride, 1], padding='SAME')
+    return tf.nn.bias_add(conv_output, biases)
+
+
+def conv2d(input_layer, w, b, stride=1):
+    conv_output = tf.nn.conv2d(input_layer, w, strides=[1, stride, stride, 1], padding='SAME')
+    return tf.nn.bias_add(conv_output, b)
+
+
+def spatial_batch_norm(input_layer, name='spatial_batch_norm'):
+    """
+    Batch-normalizes the layer as in http://arxiv.org/abs/1502.03167
+    This is important since it allows the different scales to talk to each other when they get joined.
+    """
+    mean, variance = tf.nn.moments(input_layer, [0, 1, 2])
+    variance_epsilon = 0.01  # TODO: Check what this value should be
+    inv = tf.rsqrt(variance + variance_epsilon)
+    num_channels = input_layer.get_shape().as_list()[3]  # TODO: Clean this up
+    scale = tf.Variable(tf.random_uniform([num_channels]), name='scale')  # TODO: How should these initialize?
+    offset = tf.Variable(tf.random_uniform([num_channels]), name='offset')
+    return_val = tf.sub(tf.mul(tf.mul(scale, inv), tf.sub(input_layer, mean)), offset, name=name)
+    return return_val

--- a/perceptual_loss_network.py
+++ b/perceptual_loss_network.py
@@ -1,0 +1,86 @@
+"""
+Implementation of style transfer network defined in "Perceptual Losses for Real-Time
+Style Transfer and Super-Resolution", http://arxiv.org/abs/1603.08155
+"""
+
+import tensorflow as tf
+
+from coco_data import COCODataBatcher
+from network_helpers import conv2d_with_weights, spatial_batch_norm, load_image
+from style_helpers import total_variation
+from vgg_network import VGGNetwork
+
+
+def nonresidual_block(input_layer, num_filters):
+    """
+    Constructs a block without residual
+    """
+    with tf.get_default_graph().name_scope('nonresidual-block'):
+        conv1 = conv2d_with_weights(input_layer, 3, num_filters)
+        bn1 = spatial_batch_norm(conv1)
+        relu = tf.nn.relu(bn1)
+        conv2 = conv2d_with_weights(relu, 3, num_filters)
+        output = spatial_batch_norm(conv2)
+    return output
+
+
+def residual_block(input_layer, num_filters):
+    """
+    Constructs a block as detailed in http://cs.stanford.edu/people/jcjohns/papers/fast-style/fast-style-supp.pdf
+    """
+    with tf.get_default_graph().name_scope('residual-block'):
+        output = tf.add(nonresidual_block(input_layer, num_filters), input_layer)
+    return output
+
+
+class PerceptualLossNetwork(object):
+    inputDimension = 224
+    batchSize = 4
+
+    def __init__(self, style_image_path):
+        self.graph = tf.Graph()
+        with self.graph.as_default():
+            inputDim = self.inputDimension
+            batchSize = self.batchSize
+            halfInputDim = int(inputDim / 2)
+            quarterInputDim = int(inputDim / 4)
+            self.content_image = tf.placeholder(tf.float32, [batchSize, inputDim, inputDim, 3])
+            layer1 = conv2d_with_weights(self.content_image, 9, 32)
+            layer2 = conv2d_with_weights(layer1, 3, 64, stride=2)
+            layer3 = conv2d_with_weights(layer2, 3, 128, stride=2)
+            layer4 = residual_block(layer3, 128)
+            layer5 = residual_block(layer4, 128)
+            layer6 = residual_block(layer5, 128)
+            layer7 = residual_block(layer6, 128)
+            layer8 = residual_block(layer7, 128)
+            layer9 = tf.nn.conv2d_transpose(layer8, tf.Variable(tf.random_uniform([quarterInputDim, quarterInputDim, 64, 128])), [batchSize, halfInputDim, halfInputDim, 64], [1, 2, 2, 1])
+            layer10 = tf.nn.conv2d_transpose(layer9, tf.Variable(tf.random_uniform([halfInputDim, halfInputDim, 32, 64])), [batchSize, inputDim, inputDim, 32], [1, 2, 2, 1])
+            self.output = conv2d_with_weights(layer10, 3, 3)
+            self.style_image = tf.to_float(tf.reshape(tf.constant(load_image(style_image_path)), [1, 224, 224, 3]))
+
+            vgg_input = tf.concat(0, [self.style_image, self.content_image, self.output])
+            # Feed output to VGG, compute loss against input image and style image.
+            vgg_net = VGGNetwork('vgg', vgg_input, 1, self.batchSize, self.batchSize)
+            self.style_loss = vgg_net.style_loss([(1, 2), (2, 2), (3, 3), (4, 3)])
+            self.content_loss = vgg_net.content_loss([(2, 2)])
+            # Alternatively, self.network_loss = vgg_net.combined_loss([(1, 2), (2, 2), (3, 3), (4, 3)], [(2, 2)])
+            # but this is currently more useful for debugging and inspecting the losses separately
+            self.network_loss = tf.add(self.style_loss, self.content_loss)
+            self.variation_regularizer_loss = total_variation(self.output)  # For smoothing
+            self.loss = tf.add(self.network_loss, self.variation_regularizer_loss)
+
+    def run_train(self, epochs):
+        with self.graph.as_default():
+            # Gradient descent. Draw minibatches of images from COCO.
+            batcher = COCODataBatcher('data')
+            optimizer = tf.train.AdamOptimizer(learning_rate=0.1, beta1=0.9, beta2=0.999, epsilon=1e-08,
+                                               use_locking=False, name='Adam')
+            train_step = optimizer.minimize(self.loss)
+
+            with tf.Session() as sess:
+                init = tf.initialize_all_variables()
+                sess.run(init)
+                for e in range(epochs):
+                    batch = batcher.get_batch(self.batchSize)
+                    train_step.run(feed_dict={self.content_image: batch})
+                    print("loss after ", e, sess.run(self.loss, feed_dict={self.content_image: batch}))

--- a/perceptual_loss_network.py
+++ b/perceptual_loss_network.py
@@ -6,7 +6,7 @@ Style Transfer and Super-Resolution", http://arxiv.org/abs/1603.08155
 import tensorflow as tf
 
 from coco_data import COCODataBatcher
-from network_helpers import conv2d_with_weights, spatial_batch_norm, load_image
+from network_helpers import conv2d_with_weights, conv2d_block_with_weights, spatial_batch_norm, load_image
 from style_helpers import total_variation
 from vgg_network import VGGNetwork
 
@@ -45,9 +45,9 @@ class PerceptualLossNetwork(object):
             halfInputDim = int(inputDim / 2)
             quarterInputDim = int(inputDim / 4)
             self.content_image = tf.placeholder(tf.float32, [batchSize, inputDim, inputDim, 3])
-            layer1 = conv2d_with_weights(self.content_image, 9, 32)
-            layer2 = conv2d_with_weights(layer1, 3, 64, stride=2)
-            layer3 = conv2d_with_weights(layer2, 3, 128, stride=2)
+            layer1 = conv2d_block_with_weights(self.content_image, 9, 32)
+            layer2 = conv2d_block_with_weights(layer1, 3, 64, stride=2)
+            layer3 = conv2d_block_with_weights(layer2, 3, 128, stride=2)
             layer4 = residual_block(layer3, 128)
             layer5 = residual_block(layer4, 128)
             layer6 = residual_block(layer5, 128)
@@ -55,7 +55,7 @@ class PerceptualLossNetwork(object):
             layer8 = residual_block(layer7, 128)
             layer9 = tf.nn.conv2d_transpose(layer8, tf.Variable(tf.random_uniform([quarterInputDim, quarterInputDim, 64, 128])), [batchSize, halfInputDim, halfInputDim, 64], [1, 2, 2, 1])
             layer10 = tf.nn.conv2d_transpose(layer9, tf.Variable(tf.random_uniform([halfInputDim, halfInputDim, 32, 64])), [batchSize, inputDim, inputDim, 32], [1, 2, 2, 1])
-            self.output = conv2d_with_weights(layer10, 3, 3)
+            self.output = conv2d_block_with_weights(layer10, 3, 3)
             self.style_image = tf.to_float(tf.reshape(tf.constant(load_image(style_image_path)), [1, 224, 224, 3]))
 
             vgg_input = tf.concat(0, [self.style_image, self.content_image, self.output])

--- a/style_helpers.py
+++ b/style_helpers.py
@@ -13,3 +13,27 @@ def gramian(activations):
     transposed_vectorized_activations = tf.transpose(vectorized_activations, perm=[0, 2, 1])
     mult = tf.batch_matmul(vectorized_activations, transposed_vectorized_activations)
     return mult
+
+
+def total_variation(image_batch):
+    """
+    :param image_batch: A 4D tensor of shape [batch_size, width, height, channels]
+    """
+    batch_shape = image_batch.get_shape().as_list()
+    width = batch_shape[1]
+    left = tf.slice(image_batch, [0, 0, 0, 0], [-1, width - 1, -1, -1])
+    right = tf.slice(image_batch, [0, 1, 0, 0], [-1, -1, -1, -1])
+
+    height = batch_shape[2]
+    top = tf.slice(image_batch, [0, 0, 0, 0], [-1, -1, height - 1, -1])
+    bottom = tf.slice(image_batch, [0, 0, 1, 0], [-1, -1, -1, -1])
+
+    # left and right are 1 less wide than the original, top and bottom 1 less tall
+    # In order to combine them, we take 1 off the height of left-right, and 1 off width of top-bottom
+    horizontal_diff = tf.slice(tf.sub(left, right), [0, 0, 0, 0], [-1, -1, height - 1, -1])
+    vertical_diff = tf.slice(tf.sub(top, bottom), [0, 0, 0, 0], [-1, width - 1, -1, -1])
+
+    sum_of_pixel_diffs_squared = tf.add(tf.square(horizontal_diff), tf.square(vertical_diff))
+    total_variation = tf.reduce_sum(tf.sqrt(sum_of_pixel_diffs_squared))
+    # TODO: Should this be normalized by the number of pixels?
+    return total_variation

--- a/texture_network.py
+++ b/texture_network.py
@@ -1,32 +1,12 @@
 import numpy as np
-from PIL import Image
+import skimage.io
 import tensorflow as tf
-from vgg_network import VGGNetwork, load_image
 
+from network_helpers import conv2d, spatial_batch_norm, load_image
+from vgg_network import VGGNetwork
 
 def leaky_relu(input_layer, alpha):
     return tf.maximum(tf.mul(input_layer, alpha), input_layer)
-
-
-def conv2d(name, input_layer, w, b):
-    # TODO: Mirror pad? I'm not sure how important this is.
-    conv_output = tf.nn.conv2d(input_layer, w, strides=[1, 1, 1, 1], padding='SAME')
-    return tf.nn.bias_add(conv_output, b)
-
-
-def spatial_batch_norm(input_layer, name='spatial_batch_norm'):
-    """
-    Batch-normalizes the layer as in http://arxiv.org/abs/1502.03167
-    This is important since it allows the different scales to talk to each other when they get joined.
-    """
-    mean, variance = tf.nn.moments(input_layer, [0, 1, 2])
-    variance_epsilon = 0.01  # TODO: Check what this value should be
-    inv = tf.rsqrt(variance + variance_epsilon)
-    num_channels = input_layer.get_shape().as_list()[3]  # TODO: Clean this up
-    scale = tf.Variable(tf.random_uniform([num_channels]), name='scale')  # TODO: How should these initialize?
-    offset = tf.Variable(tf.random_uniform([num_channels]), name='offset')
-    return_val = tf.sub(tf.mul(tf.mul(scale, inv), tf.sub(input_layer, mean)), offset, name=name)
-    return return_val
 
 
 def input_pyramid(name, M, batch_size, k=5):
@@ -60,7 +40,8 @@ def conv_block(name, input_layer, kernel_size, out_channels):
         high = np.sqrt(6.0/(in_channels + out_channels))
         weights = tf.Variable(tf.random_uniform([kernel_size, kernel_size, in_channels, out_channels], minval=low, maxval=high), name='weights')
         biases = tf.Variable(tf.random_uniform([out_channels], minval=low, maxval=high), name='biases')
-        conv = conv2d('conv', input_layer, weights, biases)
+        # TODO: Mirror pad the conv2d? I'm not sure how important this is.
+        conv = conv2d(input_layer, weights, biases)
         batch_norm = spatial_batch_norm(conv)
         relu = leaky_relu(batch_norm, .01)
         return relu
@@ -95,64 +76,59 @@ class TextureNetwork(object):
     batchSize = 1  # 16 in the paper
     epochs = 1000  # 2000 in the paper
 
-    def __init__(self):
+    def __init__(self, style_img_path):
         self.graph = tf.Graph()
         with self.graph.as_default():
             """
             Construct the texture network graph structure
             """
-            noise_inputs = input_pyramid("noise", self.inputDimension, self.batchSize)
+            self.noise_inputs = input_pyramid("noise", self.inputDimension, self.batchSize)
             current_channels = 8
-            current_noise_aggregate = noise_inputs[0]
-            for noise_frame in noise_inputs[1:]:
+            current_noise_aggregate = self.noise_inputs[0]
+            for noise_frame in self.noise_inputs[1:]:
                 low_res_out = conv_chain("chain_lower_%d" % current_channels, current_noise_aggregate, current_channels)
                 high_res_out = conv_chain("chain_higher", noise_frame, self.channelStepSize)
                 current_channels += self.channelStepSize
                 current_noise_aggregate = join_block("join_%d" % (current_channels + self.channelStepSize), low_res_out, high_res_out)
             final_chain = conv_chain("output_chain", current_noise_aggregate, current_channels)
-            output = conv_block("output", final_chain, kernel_size=1, out_channels=3)
+            self.output = conv_block("output", final_chain, kernel_size=1, out_channels=3)
 
             """
             Calculate style loss by computing gramians from both the output of the texture net above and from the
             texture sample image.
             """
-            texture_vgg = VGGNetwork("texture_vgg", output)
-            texture_sample_image = tf.placeholder("float", [1, 224, 224, 3])
-            image_vgg = VGGNetwork("image_vgg", texture_sample_image)
+            self.texture_image = tf.to_float(tf.constant(load_image(style_img_path).reshape((1, 224, 224, 3))))
+            #content_images = tf.placeholder("float", [self.batchSize, 224, 224, 3])
+            image_vgg = VGGNetwork("image_vgg", tf.concat(0, [self.texture_image, self.output, self.output]), 1, self.batchSize, self.batchSize)
 
-            # The tiling here is necessary because we're operating on a batch of noise samples, but only a one texture
-            layers = [i for i in range(1, 6)]
-            gramian_diffs = [tf.sub(texture_vgg.gramian_for_layer(x), tf.tile(image_vgg.gramian_for_layer(x), [self.batchSize, 1, 1])) for x in layers]
-            Ns = [texture_vgg.channels_for_layer(i) for i in layers]
-            Ms = [g.get_shape().as_list()[1] * g.get_shape().as_list()[2] for g in gramian_diffs]
-            scaled_diffs = [tf.div(tf.square(g), 4*(N**2)*(M**2)) for g, N, M in zip(gramian_diffs, Ns, Ms)]
-            # 1 / len(layers) = w_l
-            loss = tf.div(tf.add_n([tf.reduce_sum(x) for x in scaled_diffs]), len(layers))
-            optimizer = tf.train.GradientDescentOptimizer(0.1)
-            train_step = optimizer.minimize(loss)
+            self.loss = image_vgg.style_loss([(i, 1) for i in range(1, 6)])
+
+    def run_train(self):
+        with self.graph.as_default():
+            optimizer = tf.train.AdamOptimizer(learning_rate=0.01, beta1=0.9, beta2=0.999, epsilon=1e-08, use_locking=False, name='Adam')
+            train_step = optimizer.minimize(self.loss)
 
             """
             Train over epochs, printing loss at each one
             """
-            texture_image = load_image("img/img.jpg").reshape((1, 224, 224, 3))
             saver = tf.train.Saver()
             with tf.Session() as sess:
                 init = tf.initialize_all_variables()
                 sess.run(init)
-
                 for i in range(self.epochs):
                     feed_dict = {}
                     noise = noise_pyramid(self.inputDimension, self.batchSize)
-                    for index, noise_frame in enumerate(noise_inputs):
+                    for index, noise_frame in enumerate(self.noise_inputs):
                         feed_dict[noise_frame] = noise[index]
-                    feed_dict[texture_sample_image] = texture_image
                     train_step.run(feed_dict=feed_dict)
+                    # print("loss", i, sess.run(self.loss, feed_dict=feed_dict))
                     if i > 0 and i % 20 == 0:  # TODO: Make this interval an argument
                         saver.save(sess, "models/snapshot-%d.ckpt" % i)
-                        network_out = sess.run([output], feed_dict=feed_dict)
-                        img = Image.fromarray(network_out[0][0, :, :, :], "RGB")
-                        img.save("img/iteration-%d.jpeg" % i)
+                        network_out = sess.run(self.output, feed_dict=feed_dict).reshape((224, 224, 3))
+                        img_out = np.clip(np.array(network_out) * 255.0, 0, 255).astype('uint8')
+                        skimage.io.imsave("img/aa-iteration-%d.jpeg" % i, img_out)
 
 
 # TODO: Add argument parsing and command-line args
-TextureNetwork()
+t = TextureNetwork('img/style.jpg')
+t.run_train()

--- a/vgg_network.py
+++ b/vgg_network.py
@@ -1,31 +1,24 @@
 """
-Partially taken from https://github.com/ry/tensorflow-vgg16/blob/master/tf_forward.py
-Loads vgg16 from disk as a tensorflow model.
+Loads vgg16 from disk as a tensorflow model with batching to process style, content, and synthesized images
+simultaneously (while abstracting the accessors to compute style/content loss based on that representation).
 """
-import skimage.io
-import skimage.transform
 from style_helpers import gramian
 import tensorflow as tf
 
 
-def load_image(path):
-    # load image
-    img = skimage.io.imread(path) / 255.0
-    assert (0 <= img).all() and (img <= 1.0).all()
-    # we crop image from center
-    short_edge = min(img.shape[:2])
-    yy = int((img.shape[0] - short_edge) / 2)
-    xx = int((img.shape[1] - short_edge) / 2)
-    crop_img = img[yy : yy + short_edge, xx : xx + short_edge]
-    # resize to 224, 224
-    resized_img = skimage.transform.resize(crop_img, (224, 224))
-    return resized_img
-
-
 class VGGNetwork(object):
 
-    def __init__(self, name, input):
+    def __init__(self, name, input, i, j, k):
+        """
+        :param input: A 4D-tensor of shape [batchSize, 224, 224, 3]
+                [0:i, :, :, :] holds i style images,
+                [i:i+j, :, :, :] holds j content images,
+                [i+j:i+j+k, :, :, :] holds k synthesized images
+        """
         self.name = name
+        self.num_style = i
+        self.num_content = j
+        self.num_synthesized = k
         with open("models/vgg16.tfmodel", mode='rb') as f:
             file_content = f.read()
         graph_def = tf.GraphDef()
@@ -46,8 +39,49 @@ class VGGNetwork(object):
         """
         Returns a matrix of cross-correlations between the activations of convolutional channels in a given layer.
         """
-        activations = tf.get_default_graph().get_tensor_by_name("%s/conv%d_1/Relu:0" % (self.name, layer))
+        activations = self.activations_for_layer(layer)
 
         # Reshape from (batch, width, height, channels) to (batch, channels, width, height)
         shuffled_activations = tf.transpose(activations, perm=[0, 3, 1, 2])
         return gramian(shuffled_activations)
+
+    def activations_for_layer(self, layer):
+        """
+        :param layer: A tuple that indexes into the convolutional blocks of the VGG Net
+        """
+        return tf.get_default_graph().get_tensor_by_name("{0}/conv{1}_{2}/Relu:0".format(self.name, layer[0], layer[1]))
+
+    def style_loss(self, layers):
+        activations = [self.activations_for_layer(i) for i in layers]
+        gramians = [self.gramian_for_layer(x) for x in layers]
+        # Slices are for style and synth image
+        gramian_diffs = [
+            tf.sub(
+                tf.tile(tf.slice(g, [0, 0, 0], [self.num_style, -1, -1]), [self.num_synthesized - self.num_style + 1, 1, 1]),
+                tf.slice(g, [self.num_style + self.num_content, 0, 0], [self.num_synthesized, -1, -1]))
+            for g in gramians]
+        Ns = [g.get_shape().as_list()[2] for g in gramians]
+        Ms = [a.get_shape().as_list()[1] * a.get_shape().as_list()[2] for a in activations]
+        scaled_diffs = [tf.square(g) for g in gramian_diffs]
+        style_loss = tf.div(
+            tf.add_n([tf.div(tf.reduce_sum(x), 4 * (N ** 2) * (M ** 2)) for x, N, M in zip(scaled_diffs, Ns, Ms)]),
+            len(layers))
+        return style_loss
+
+    def content_loss(self, layers):
+        activations = [self.activations_for_layer(i) for i in layers]
+        activation_diffs = [
+            tf.sub(
+                tf.tile(tf.slice(a, [self.num_style, 0, 0, 0], [self.num_content, -1, -1, -1]), [self.num_synthesized - self.num_content + 1, 1, 1, 1]),
+                tf.slice(a, [self.num_style + self.num_content, 0, 0, 0], [self.num_content, -1, -1, -1]))
+            for a in activations]
+        # This normalizer is in JCJohnson's paper, but not Gatys' I think?
+        Ns = [a.get_shape().as_list()[1] * a.get_shape().as_list()[2] * a.get_shape().as_list()[3] for a in activations]
+        content_loss = tf.div(tf.add_n([tf.div(tf.reduce_sum(tf.square(a)), n) for a, n in zip(activation_diffs, Ns)]), 2.0)
+        return content_loss
+
+    def combined_loss(self, style_layers, content_layers, alpha=0.001, beta=1.0):
+        style_loss = self.style_loss(style_layers)
+        content_loss = self.content_loss(content_layers)
+        combined_loss = tf.add(tf.mul(beta, style_loss), tf.mul(alpha, content_loss))
+        return combined_loss


### PR DESCRIPTION
Also cleaned up the Ulyanov network so that network initialization and training are separated, as well as the VGG network so that it can take in a stack of style, content, and synthesized images for faster processing and lower memory usage.
